### PR TITLE
searchHero local endpoint fixed

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,14 +22,14 @@ import { MessagesComponent }    from './messages/messages.component';
     BrowserModule,
     FormsModule,
     AppRoutingModule,
-    HttpClientModule
+    HttpClientModule,
 
     // The HttpClientInMemoryWebApiModule module intercepts HTTP requests
     // and returns simulated server responses.
     // Remove it when a real server is ready to receive requests.
-    /*HttpClientInMemoryWebApiModule.forRoot(
+    HttpClientInMemoryWebApiModule.forRoot(
       InMemoryDataService, { dataEncapsulation: false }
-    )*/
+    )
   ],
   declarations: [
     AppComponent,

--- a/src/app/hero.service.ts
+++ b/src/app/hero.service.ts
@@ -59,7 +59,7 @@ export class HeroService {
       // if not search term, return empty hero array.
       return of([]);
     }
-    return this.http.get<Hero[]>(`${this.heroesUrl}${term}`).pipe(
+    return this.http.get<Hero[]>(`${this.heroesUrl}?name=${term}`).pipe(
       tap(_ =>
         this.log(`found heroes matching "${term}"`)),
       catchError(this.handleError<Hero[]>('searchHeroes', []))

--- a/src/app/hero.ts
+++ b/src/app/hero.ts
@@ -1,5 +1,4 @@
 export class Hero {
-  
   id: number;
   name: string;
 }

--- a/src/app/hero.ts
+++ b/src/app/hero.ts
@@ -1,4 +1,5 @@
 export class Hero {
+  
   id: number;
   name: string;
 }


### PR DESCRIPTION
The searchHero used to work with this URI: ./heroes/findByName/{name}

From now on, to match the Angular2 tutorial and to equilibrate, the URI will be:
./heroes/?name={name}